### PR TITLE
Fixes percentages used in Group and Type advanced filters

### DIFF
--- a/src/Helpers/SrpManager.php
+++ b/src/Helpers/SrpManager.php
@@ -136,9 +136,9 @@ trait SrpManager
 
         $source = $rule->price_source;
         $base_value = $rule->base_value;
-        $hull_percent = $rule->hull_percent;
-        $fit_percent = $rule->fit_percent;
-        $cargo_percent = $rule->cargo_percent;
+        $hull_percent = $rule->hull_percent / 100;
+        $fit_percent = $rule->fit_percent / 100;
+        $cargo_percent = $rule->cargo_percent / 100;
         $deduct_insurance = $rule->deduct_insurance;
         $price_cap = $rule->srp_price_cap;
 

--- a/src/resources/views/srptest.blade.php
+++ b/src/resources/views/srptest.blade.php
@@ -155,9 +155,9 @@
                     // id_to_names();
                     $('#type').text(result["price"]["rule"]);
                     $('#base').text(result["price"]["base_value"].toLocaleString() + " ISK");
-                    $('#hull').text((result["price"]["hull_percent"] * 100).toLocaleString() + " %");
-                    $('#fit').text((result["price"]["fit_percent"] * 100).toLocaleString() + " %");
-                    $('#cargo').text((result["price"]["cargo_percent"] * 100).toLocaleString() + " %");
+                    $('#hull').text((result["price"]["hull_percent"]).toLocaleString() + " %");
+                    $('#fit').text((result["price"]["fit_percent"]).toLocaleString() + " %");
+                    $('#cargo').text((result["price"]["cargo_percent"]).toLocaleString() + " %");
                     $('#insurance').text(result["price"]["deduct_insurance"]);
                     $('#error').text(result["price"]["error"]);
 


### PR DESCRIPTION
The percentages for hull, fit, and cargo were treated as a percent but they are only integers.  This fixes the pricing issue.

This should fix #4 